### PR TITLE
Fixed: error.log StackTrace info was overwrite.

### DIFF
--- a/BaiduPanDownloadWpf/Bootstrapper.cs
+++ b/BaiduPanDownloadWpf/Bootstrapper.cs
@@ -62,66 +62,47 @@ namespace BaiduPanDownloadWpf
             //var message = $"Message: {(e.ExceptionObject as Exception)?.Message}, StackTrace: {(e.ExceptionObject as Exception)?.StackTrace}";
             //Logger.Log(message, Category.Exception, Priority.High);
             // ------------------------------------------------------------------------------------------------------------------------------------
-            var exception = (Exception)e.ExceptionObject;
-            var log = new StringBuilder();
-            log.AppendLine("程序在运行时遇到不可预料的错误");
-            log.AppendLine("=======追踪开始=======");
-            log.AppendLine();
-            log.AppendLine("Time: " + DateTime.Now);
-            log.AppendLine("Type: " + exception.GetType().Name);
-            log.AppendLine("Message: " + exception.Message);
-            log.AppendLine("Version: 0.1.0.63");
-            log.AppendLine("StackTrace: ");
-            log.AppendLine(exception.StackTrace);
-            log.AppendLine();
-            log.AppendLine("=======追踪结束=======");
-            log.AppendLine("请将以上信息提供给开发者以供参考");
-            if (File.Exists(Path.Combine(Directory.GetCurrentDirectory(), "Error.log")))
-            {
-                try
-                {
-                    File.Delete(Path.Combine(Directory.GetCurrentDirectory(), "Error.log"));
-                }
-                catch
-                {
-                    throw exception;
-                }
-            }
-            File.WriteAllText(Path.Combine(Directory.GetCurrentDirectory(), "Error.log"), log.ToString());
-            throw exception;
+            this.CatchException(e.ExceptionObject as Exception);
         }
 
         private void OnDispatcherUnhandledExceptionOccurred(object sender, DispatcherUnhandledExceptionEventArgs e)
         {
             var message = $"Message: {e.Exception.Message}, StackTrace: {Environment.NewLine}{e.Exception.StackTrace}{Environment.NewLine}";
             Logger.Log(message, Category.Exception, Priority.High);
-            // ------------------------------------------------------------------------------------------------------------------------------------
+            this.CatchException(e.Exception);
+        }
+
+        private void CatchException(Exception error)
+        {
+            if (error == null) return;
+
             var log = new StringBuilder();
             log.AppendLine("程序在运行时遇到不可预料的错误");
             log.AppendLine("=======追踪开始=======");
             log.AppendLine();
             log.AppendLine("Time: " + DateTime.Now);
-            log.AppendLine("Type: " + e.GetType().Name);
+            log.AppendLine("Type: " + error.GetType().Name);
             log.AppendLine("Version: 0.1.0.63");
-            log.AppendLine("Message: " + e.Exception == null ? "无信息" : e.Exception.Message);
+            log.AppendLine("Message: " + error.Message);
             log.AppendLine("StackTrace: ");
-            log.AppendLine(e.Exception == null ? "无信息" : e.Exception.StackTrace);
+            log.AppendLine(error.StackTrace);
             log.AppendLine();
             log.AppendLine("=======追踪结束=======");
             log.AppendLine("请将以上信息提供给开发者以供参考");
-            if (File.Exists(Path.Combine(Directory.GetCurrentDirectory(), "Error.log")))
+
+            var path = Path.Combine(Directory.GetCurrentDirectory(), "Error.log");
+            try
             {
-                try
-                {
-                    File.Delete(Path.Combine(Directory.GetCurrentDirectory(), "Error.log"));
-                }
-                catch
-                {
-                    throw e.Exception;
-                }
+                File.WriteAllText(path, log.ToString());
             }
-            File.WriteAllText(Path.Combine(Directory.GetCurrentDirectory(), "Error.log"), log.ToString());
-            throw e.Exception;
+            catch (Exception e)
+            {
+                this.Logger.Log(e.ToString(), Category.Exception, Priority.High);
+            }
+            finally
+            {
+                Environment.Exit(-1);
+            }
         }
     }
 }


### PR DESCRIPTION
先看一下某个异常报告：

``` text
程序在运行时遇到不可预料的错误
=======追踪开始=======

Time: 2017/3/11 11:43:24
Type: InvalidOperationException
Message: 集合已修改；可能无法执行枚举操作。
Version: 0.1.0.63
StackTrace: 
   在 BaiduPanDownloadWpf.Bootstrapper.OnDispatcherUnhandledExceptionOccurred(Object sender, DispatcherUnhandledExceptionEventArgs e) 位置 C:\Users\18448\Source\Workspaces\BaiduPanDownloadWpf\BaiduPanDownloadWpf\Bootstrapper.cs:行号 96
   在 System.Windows.Threading.Dispatcher.CatchException(Exception e)
   在 System.Windows.Threading.Dispatcher.CatchExceptionStatic(Object source, Exception e)
   在 System.Windows.Threading.ExceptionWrapper.CatchException(Object source, Exception e, Delegate catchHandler)
   在 System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
   在 System.Windows.Threading.DispatcherOperation.InvokeImpl()
   在 System.Windows.Threading.DispatcherOperation.InvokeInSecurityContext(Object state)
   在 System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   在 System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   在 System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
   在 MS.Internal.CulturePreservingExecutionContext.Run(CulturePreservingExecutionContext executionContext, ContextCallback callback, Object state)
   在 System.Windows.Threading.DispatcherOperation.Invoke()
   在 System.Windows.Threading.Dispatcher.ProcessQueue()
   在 System.Windows.Threading.Dispatcher.WndProcHook(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   在 MS.Win32.HwndWrapper.WndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   在 MS.Win32.HwndSubclass.DispatcherCallbackOperation(Object o)
   在 System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   在 System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
   在 System.Windows.Threading.Dispatcher.LegacyInvokeImpl(DispatcherPriority priority, TimeSpan timeout, Delegate method, Object args, Int32 numArgs)
   在 MS.Win32.HwndSubclass.SubclassWndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam)
   在 MS.Win32.UnsafeNativeMethods.DispatchMessage(MSG& msg)
   在 System.Windows.Threading.Dispatcher.PushFrameImpl(DispatcherFrame frame)
   在 System.Windows.Threading.Dispatcher.PushFrame(DispatcherFrame frame)
   在 System.Windows.Application.RunDispatcher(Object ignore)
   在 System.Windows.Application.RunInternal(Window window)
   在 System.Windows.Application.Run(Window window)
   在 BaiduPanDownloadWpf.App.Main()

=======追踪结束=======
请将以上信息提供给开发者以供参考
```

出现这种没用堆栈信息的原因：

1. `OnDispatcherUnhandledExceptionOccurred()` 函数获取到正确的堆栈信息，并写到 error.log 里了。
1. `OnDispatcherUnhandledExceptionOccurred()` 最后一句 `throw e.Exception;` 重置了异常的堆栈，此后异常的堆栈是无效状态。
1. `OnUnhandledExceptionOccurred()` catch 到上述 throw 的 `e.Exception`，并删掉了包含正确堆栈信息的 error.log，然后写了不正确的 error.log。
1. 抠鼻。